### PR TITLE
Choose nachgeruestet

### DIFF
--- a/src/Klio.jl
+++ b/src/Klio.jl
@@ -3,7 +3,7 @@ module Klio
 using Dates
 using Genie
 
-import Genie.Router: route, POST
+import Genie.Router: route, POST, @params
 import Genie.Renderer: json
 
 run() = begin
@@ -11,6 +11,32 @@ run() = begin
 
     route("/time", method = POST) do
         Dict(:response_type => "in_channel", :text => Dates.now(Dates.UTC)) |> json
+    end
+
+    route("/choose", method = POST) do
+        nick = @params(:user_name)
+        text = @params(:text)
+        if length(text) < 1
+            reply = string("@", nick, " Du musst mir schon sagen was du mit /choose aussuchen möchtest. Das Kristallkugel-Modul bekomme ich erst in Version 2 :(")
+        else
+            options = split(text)
+            if length(options) == 1
+                # Ja/Nein
+                choice = rand(0:1)
+                reply = string("@", nick, ", deine einzige Option ist ", text, "?\nIch sage: ", choice == 0 ? "Nein" : "Ja")
+            else
+                choice = 0
+                legacy_joke = rand()
+                if legacy_joke > 0.98
+                    push!(options, "Ja")
+                    choice = length(options)
+                else
+                    choice = rand(1:length(options))
+                end
+                reply = string("@", nick, ", Du möchtest dich zwischen diesen Optionen entscheiden: ", join(options, ", "), "?\n Ich sage: ", options[choice])
+            end
+        end
+        Dict(:response_type => "in_channel", :text => reply) |> json
     end
 
     Genie.startup()


### PR DESCRIPTION
Choose nachgerüstet. Theoretisch sollte Klio bei 2% der Anfragen mit mehr als einer Option mit "Ja" antworten. Kann ja nach dem Ende des Polls zur Not einfach entfernt werden.