### PR TITLE
choose() an Outgoing Webhook angepasst

### DIFF
--- a/src/Klio.jl
+++ b/src/Klio.jl
@@ -16,26 +16,27 @@ run() = begin
     route("/choose", method = POST) do
         nick = @params(:user_name)
         text = @params(:text)
-        if length(text) < 8
-            reply = string("@", nick, " Du musst mir schon sagen was du mit !choose aussuchen möchtest. Das Kristallkugel-Modul bekomme ich erst in Version 2 :(")
+        
+        options = split(text)
+        # Weg mit dem !choose
+        popfirst!(options)
+        
+        if length(options) == 0
+            reply = string("@", nick, ", du musst mir schon sagen was du mit !choose aussuchen möchtest. Das Kristallkugel-Modul bekomme ich erst in Version 2 :(")
+        elseif length(options) == 1
+            # Ja/Nein
+            choice = rand(0:1)
+            reply = string("@", nick, ", ich sage: ", choice == 0 ? "Nein" : "Ja")
         else
-            options = split(text)
-            popfirst!(options)
-            if length(options) == 1
-                # Ja/Nein
-                choice = rand(0:1)
-                reply = string("@", nick, ", ich sage: ", choice == 0 ? "Nein" : "Ja")
+            choice = 0
+            legacy_joke = rand()
+            if legacy_joke > 0.98
+                push!(options, "Ja")
+                choice = length(options)
             else
-                choice = 0
-                legacy_joke = rand()
-                if legacy_joke > 0.98
-                    push!(options, "Ja")
-                    choice = length(options)
-                else
-                    choice = rand(1:length(options))
-                end
-                reply = string("@", nick, ", ich sage: ", options[choice])
+                choice = rand(1:length(options))
             end
+            reply = string("@", nick, ", ich sage: ", options[choice])
         end
         Dict(:response_type => "in_channel", :text => reply) |> json
     end

--- a/src/Klio.jl
+++ b/src/Klio.jl
@@ -16,14 +16,15 @@ run() = begin
     route("/choose", method = POST) do
         nick = @params(:user_name)
         text = @params(:text)
-        if length(text) < 1
-            reply = string("@", nick, " Du musst mir schon sagen was du mit /choose aussuchen möchtest. Das Kristallkugel-Modul bekomme ich erst in Version 2 :(")
+        if length(text) < 8
+            reply = string("@", nick, " Du musst mir schon sagen was du mit !choose aussuchen möchtest. Das Kristallkugel-Modul bekomme ich erst in Version 2 :(")
         else
             options = split(text)
+            popfirst!(options)
             if length(options) == 1
                 # Ja/Nein
                 choice = rand(0:1)
-                reply = string("@", nick, ", deine einzige Option ist ", text, "?\nIch sage: ", choice == 0 ? "Nein" : "Ja")
+                reply = string("@", nick, ", ich sage: ", choice == 0 ? "Nein" : "Ja")
             else
                 choice = 0
                 legacy_joke = rand()
@@ -33,7 +34,7 @@ run() = begin
                 else
                     choice = rand(1:length(options))
                 end
-                reply = string("@", nick, ", Du möchtest dich zwischen diesen Optionen entscheiden: ", join(options, ", "), "?\n Ich sage: ", options[choice])
+                reply = string("@", nick, ", ich sage: ", options[choice])
             end
         end
         Dict(:response_type => "in_channel", :text => reply) |> json


### PR DESCRIPTION
- Optionen werden nicht mehr aufgezählt, sieht man ja jetzt im Channel
- !choose wird ins Array gezogen und mit popfirst! rausgeworfen, so haben wir immer ein Array, wenn auch nur mit Länge 0 (statische Längenprüfung fällt bei "!choose  " auf die Nase)